### PR TITLE
Fix CSRF cookie

### DIFF
--- a/lib/inertia_phoenix/plug.ex
+++ b/lib/inertia_phoenix/plug.ex
@@ -29,7 +29,7 @@ defmodule InertiaPhoenix.Plug do
   end
 
   defp put_csrf_cookie(conn) do
-    conn |> put_resp_cookie("XSRF-TOKEN", Controller.get_csrf_token())
+    conn |> put_resp_cookie("XSRF-TOKEN", Controller.get_csrf_token(), http_only: false)
   end
 
   defp check_assets_version(conn) do

--- a/lib/inertia_phoenix/plug.ex
+++ b/lib/inertia_phoenix/plug.ex
@@ -9,6 +9,7 @@ defmodule InertiaPhoenix.Plug do
   def call(conn, _) do
     conn
     |> check_inertia_req
+    |> put_csrf_cookie
     |> check_assets_version
   end
 
@@ -19,12 +20,10 @@ defmodule InertiaPhoenix.Plug do
         |> put_resp_header("vary", "accept")
         |> put_resp_header("x-inertia", "true")
         |> assign(:inertia_request, true)
-        |> put_csrf_cookie
 
       _ ->
         conn
         |> assign(:inertia_request, false)
-        |> put_csrf_cookie
     end
   end
 


### PR DESCRIPTION
By default, put_resp_cookie creates an HTTP only cookie that is not accessible on document.cookie.