### PR TITLE
Ensure response is sent when assets version is invalid

### DIFF
--- a/lib/inertia_phoenix/plug.ex
+++ b/lib/inertia_phoenix/plug.ex
@@ -46,7 +46,7 @@ defmodule InertiaPhoenix.Plug do
     |> put_resp_header("x-inertia", "true")
     |> put_resp_header("x-inertia-location", request_url(conn))
     |> put_resp_content_type("text/html")
-    |> put_status(:conflict)
+    |> send_resp(:conflict, "")
     |> halt()
   end
 

--- a/test/inertia_phoenix/controller_test.exs
+++ b/test/inertia_phoenix/controller_test.exs
@@ -86,7 +86,6 @@ defmodule InertiaPhoenix.ControllerTest do
       |> fetch_session
       |> fetch_flash
       |> InertiaPhoenix.Plug.call([])
-      |> InertiaPhoenix.Controller.render_inertia("Home", props: %{hello: "world"})
 
     assert html = html_response(conn, 409)
   end


### PR DESCRIPTION
It's not enough to `put_status` when halting (see https://medium.com/adorableio/halting-plugs-in-phoenix-ce674762e488 for a bit more info). I tested this in a test app and was getting a 200 instead of a 409 when the assets version was invalid.