### PR TITLE
Inertia headers should only be set on inertia responses

### DIFF
--- a/lib/inertia_phoenix/plug.ex
+++ b/lib/inertia_phoenix/plug.ex
@@ -2,34 +2,25 @@ defmodule InertiaPhoenix.Plug do
   @moduledoc false
   import Plug.Conn
   import InertiaPhoenix
-  alias Phoenix.Controller
 
   def init(default), do: default
 
   def call(conn, _) do
     conn
     |> check_inertia_req
-    |> put_csrf_cookie
-    |> check_redirect
-    |> check_assets_version
   end
 
   defp check_inertia_req(conn) do
     case get_req_header(conn, "x-inertia") do
       ["true"] ->
         conn
-        |> put_resp_header("vary", "accept")
-        |> put_resp_header("x-inertia", "true")
+        |> check_redirect
+        |> check_assets_version
         |> assign(:inertia_request, true)
 
       _ ->
-        conn
-        |> assign(:inertia_request, false)
+        assign(conn, :inertia_request, false)
     end
-  end
-
-  defp put_csrf_cookie(conn) do
-    conn |> put_resp_cookie("XSRF-TOKEN", Controller.get_csrf_token(), http_only: false)
   end
 
   defp check_assets_version(conn) do

--- a/test/inertia_phoenix/controller_test.exs
+++ b/test/inertia_phoenix/controller_test.exs
@@ -93,7 +93,7 @@ defmodule InertiaPhoenix.ControllerTest do
   test "render_inertia/3 PUT request with 301", %{conn: conn} do
     conn =
       conn
-      |> Conn.put_req_header("x-inertia", "false")
+      |> Conn.put_req_header("x-inertia", "true")
       |> Conn.put_req_header("x-inertia-version", "1")
       |> fetch_session
       |> fetch_flash
@@ -102,7 +102,7 @@ defmodule InertiaPhoenix.ControllerTest do
       |> InertiaPhoenix.Plug.call([])
       |> InertiaPhoenix.Controller.render_inertia("Home")
 
-    assert html = html_response(conn, 303)
+    assert json = json_response(conn, 303)
   end
 
   test "render_inertia/3 with x-inertia-partial-data", %{conn: conn} do


### PR DESCRIPTION
Currently, the plug sets the inertia headers every time an inertia response is received, however, an inertia request is not always answered with an inertia response (in case of errors per example)

The current implementation breaks https://inertiajs.com/error-handling in a development environment, this is also related to #5

I also moved the checks on the plug so we only manipulate inertia requests since both redirect codes and cache bust should only happen on inertia requests