### PR TITLE
Shared Data Proposal

### DIFF
--- a/lib/inertia_phoenix/controller.ex
+++ b/lib/inertia_phoenix/controller.ex
@@ -39,7 +39,7 @@ defmodule InertiaPhoenix.Controller do
     |> lazy_load()
     |> assign_component(component)
     |> assign_flash(Controller.get_flash(conn))
-    |> assign_inertia_shared(conn)
+    |> merge_inertia_shared(conn)
   end
 
   defp page_map(conn, assigns) do
@@ -95,10 +95,10 @@ defmodule InertiaPhoenix.Controller do
     )
   end
 
-  defp assign_inertia_shared(conn, assigns) do
-    IO.inspect(assigns)
-    conn
+  defp merge_inertia_shared(assigns, %{assigns: %{inertia_share: inertia_shared}}) do
+    Keyword.put(assigns, :props, Map.merge(assigns[:props], inertia_shared))
   end
+  defp merge_inertia_shared(assigns, conn), do: assigns
 
   defp put_csrf_cookie(conn) do
     put_resp_cookie(conn, "XSRF-TOKEN", Controller.get_csrf_token(), http_only: false)

--- a/lib/inertia_phoenix/controller.ex
+++ b/lib/inertia_phoenix/controller.ex
@@ -33,6 +33,15 @@ defmodule InertiaPhoenix.Controller do
     |> Controller.render("inertia.html", assigns)
   end
 
+  defp build_assigns(conn, assigns, component) do
+    assigns
+    |> filter_partial_data(conn)
+    |> lazy_load()
+    |> assign_component(component)
+    |> assign_flash(Controller.get_flash(conn))
+    |> assign_inertia_shared(conn)
+  end
+
   defp page_map(conn, assigns) do
     assigns_map = Enum.into(assigns, %{})
 
@@ -86,12 +95,9 @@ defmodule InertiaPhoenix.Controller do
     )
   end
 
-  defp build_assigns(conn, assigns, component) do
-    assigns
-    |> filter_partial_data(conn)
-    |> lazy_load()
-    |> assign_component(component)
-    |> assign_flash(Controller.get_flash(conn))
+  defp assign_inertia_shared(conn, assigns) do
+    IO.inspect(assigns)
+    conn
   end
 
   defp put_csrf_cookie(conn) do

--- a/lib/inertia_phoenix/plug.ex
+++ b/lib/inertia_phoenix/plug.ex
@@ -3,11 +3,10 @@ defmodule InertiaPhoenix.Plug do
   import Plug.Conn
   import InertiaPhoenix
 
-  def init(inertia_shared), do: inertia_shared
+  def init(default), do: default
 
-  def call(conn, inertia_shared) do
+  def call(conn, _) do
     conn
-    |> assign(:inertia_shared, inertia_shared)
     |> check_inertia_req
   end
 

--- a/lib/inertia_phoenix/plug.ex
+++ b/lib/inertia_phoenix/plug.ex
@@ -3,10 +3,11 @@ defmodule InertiaPhoenix.Plug do
   import Plug.Conn
   import InertiaPhoenix
 
-  def init(default), do: default
+  def init(inertia_shared), do: inertia_shared
 
-  def call(conn, _) do
+  def call(conn, inertia_shared) do
     conn
+    |> assign(:inertia_shared, inertia_shared)
     |> check_inertia_req
   end
 


### PR DESCRIPTION
ref: #1 

**Some Notes:**

- With this implementation, end-user will need to configure their data manually using a Plug.
- This is similar to how the rails lib works, as they just use concerns wrap controller request.
- I opted not to use a conn.private as the end-user will be configuring their data, they'll likely understand their own assigns and be able to resolve conflicts pretty easily.
- `:inertia_share` must be a map, as it'll be merged with props.
- `:inertia_share` will overwrite any props that are passed when they're merged with props.

**Example Custom Plug**
```
  defmodule PingWeb.Plugs.InertiaShare do
    def init(default), do: default
    alias Plug.Conn
    alias Ping.Users.User

    def call(conn, _) do
      conn
      |> Conn.assign(:inertia_share, inertia_share_data(conn))
    end

    defp inertia_share_data(conn) do
      Map.new()
      |> Map.put(:auth, build_auth_map(conn))
    end

    defp build_auth_map(conn) do
      case Pow.Plug.current_user(conn) do
        %User{} = current_user ->
          %{
            user: %{
              account: %{name: "Account"},
              first_name: "Tom",
              id: current_user.id,
              last_name: "Jones"
            }
          }
        _ -> %{}
      end
    end
  end
```
Let me know if you have any feedback or concerns.