### PR TITLE
Add check for matching x-inertia-partial-component

### DIFF
--- a/lib/inertia_phoenix/plug.ex
+++ b/lib/inertia_phoenix/plug.ex
@@ -42,13 +42,15 @@ defmodule InertiaPhoenix.Plug do
   end
 
   def check_redirect(conn) do
-    conn
-    |> register_before_send(fn conn ->
-      if conn.method in ["PUT", "PATCH", "DELETE"] and conn.status in [301, 302] do
-        put_status(conn, 303)
-      else
-        conn
+    register_before_send(
+      conn,
+      fn conn ->
+        if conn.method in ["PUT", "PATCH", "DELETE"] and conn.status in [301, 302] do
+          put_status(conn, 303)
+        else
+          conn
+        end
       end
-    end)
+    )
   end
 end


### PR DESCRIPTION
Add a check for x-inertia-partial-component as per https://inertiajs.com/the-protocol#asset-versioning

> The X-Inertia-Partial-Component header includes the name of the component that is being partially reloaded. This is necessary, since partial reloads only work for requests made to the same page component. If the final destination is different for whatever reason (eg. the user was logged out and is now on the login page), then no partial reloading will occur.