### PR TITLE
Add check for matching x-inertia-partial-component

### DIFF
--- a/test/inertia_phoenix/controller_test.exs
+++ b/test/inertia_phoenix/controller_test.exs
@@ -86,7 +86,8 @@ defmodule InertiaPhoenix.ControllerTest do
       |> fetch_session
       |> fetch_flash
       |> InertiaPhoenix.Plug.call([])
-      # |> InertiaPhoenix.Controller.render_inertia("Home", props: %{hello: "world"})
+
+    # |> InertiaPhoenix.Controller.render_inertia("Home", props: %{hello: "world"})
 
     assert html = html_response(conn, 409)
   end
@@ -111,6 +112,7 @@ defmodule InertiaPhoenix.ControllerTest do
       conn
       |> Conn.put_req_header("x-inertia", "true")
       |> Conn.put_req_header("x-inertia-version", "1")
+      |> Conn.put_req_header("x-inertia-partial-component", "Home")
       |> Conn.put_req_header("x-inertia-partial-data", "hello,foo")
       |> fetch_session
       |> fetch_flash
@@ -122,6 +124,32 @@ defmodule InertiaPhoenix.ControllerTest do
     page_map = %{
       "component" => "Home",
       "props" => %{"hello" => "world", "foo" => "bar"},
+      "url" => "/",
+      "version" => "1"
+    }
+
+    assert json = json_response(conn, 200)
+    assert json == page_map
+  end
+
+  test "render_inertia/3 with x-inertia-partial-data and mismatched x-inertia-partial-component",
+       %{conn: conn} do
+    conn =
+      conn
+      |> Conn.put_req_header("x-inertia", "true")
+      |> Conn.put_req_header("x-inertia-version", "1")
+      |> Conn.put_req_header("x-inertia-partial-component", "Dashboard")
+      |> Conn.put_req_header("x-inertia-partial-data", "hello,foo")
+      |> fetch_session
+      |> fetch_flash
+      |> InertiaPhoenix.Plug.call([])
+      |> InertiaPhoenix.Controller.render_inertia("Home",
+        props: %{hello: "world", world: "hello", foo: "bar"}
+      )
+
+    page_map = %{
+      "component" => "Home",
+      "props" => %{"hello" => "world", "world" => "hello", "foo" => "bar"},
       "url" => "/",
       "version" => "1"
     }


### PR DESCRIPTION
Add a check for x-inertia-partial-component as per https://inertiajs.com/the-protocol#asset-versioning

> The X-Inertia-Partial-Component header includes the name of the component that is being partially reloaded. This is necessary, since partial reloads only work for requests made to the same page component. If the final destination is different for whatever reason (eg. the user was logged out and is now on the login page), then no partial reloading will occur.