### PR TITLE
feat: add SSR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,29 @@ Import render_inertia `lib/active_web.ex`
   end
 ```
 
+If you want to use SSR add `InertiaPhoenix.ViewHelper` to `lib/<your app>_web.ex`
+```elixir
+  defp view_helpers do
+    quote do
+      ...
+
+      import InertiaPhoenix.ViewHelper
+
+      ...
+    end
+  end
+```
+
 ## Configuration
 
 Add to `config/config.exs`
 
 ```elixir
 config :inertia_phoenix,
-  assets_version: 1,          # default 1
-  inertia_layout: "app.html"  # default app.html
+  assets_version: 1,                 # default 1
+  inertia_layout: "app.html",        # default app.html
+  ssr_enabled: false,                # default false
+  ssr_url: "http://127.0.0.1:13714"  # default http://127.0.0.1:13714
 ```
 
 - Asset Versioning Docs: https://inertiajs.com/asset-versioning
@@ -96,6 +111,8 @@ An example layout:
 <html lang="en">
   <head>
     ...
+    <!-- add this when using SSR: -->
+    <%= inertia_head(@conn) %>
   </head>
   <body>
     <%= @inner_content %>

--- a/lib/inertia_phoenix.ex
+++ b/lib/inertia_phoenix.ex
@@ -22,6 +22,14 @@ defmodule InertiaPhoenix do
     |> to_string
   end
 
+  def inertia_ssr_enabled do
+    Application.get_env(:inertia_phoenix, :ssr_enabled, false)
+  end
+
+  def inertia_ssr_url do
+    Application.get_env(:inertia_phoenix, :ssr_url, "http://127.0.0.1:13714")
+  end
+
   def path_with_params(%{request_path: request_path, query_string: ""}), do: request_path
 
   def path_with_params(%{request_path: request_path, query_string: query_string}) do

--- a/lib/inertia_phoenix/helper.ex
+++ b/lib/inertia_phoenix/helper.ex
@@ -1,0 +1,5 @@
+defmodule InertiaPhoenix.ViewHelper do
+  def inertia_head(conn) do
+    conn.assigns[:inertia_ssr_head]
+  end
+end

--- a/lib/inertia_phoenix/view.ex
+++ b/lib/inertia_phoenix/view.ex
@@ -4,10 +4,16 @@ defmodule InertiaPhoenix.View do
   alias Phoenix.HTML.Tag
 
   def render("inertia.html", assigns) do
-    Tag.content_tag(:div, "", [
-      {:id, "app"},
-      {:data, [page: page_json(assigns)]}
-    ])
+    { body, assigns } = Map.pop(assigns, :inertia_ssr_body)
+
+    if body != "" do
+      Phoenix.HTML.raw(body)
+    else
+      Tag.content_tag(:div, "", [
+        {:id, "app"},
+        {:data, [page: page_json(assigns)]}
+      ])
+    end
   end
 
   defp page_json(%{conn: conn}) do

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,9 @@ defmodule InertiaPhoenix.MixProject do
       {:ex_doc, "~> 0.29.4", only: :dev},
       {:plug_cowboy, "~> 2.1", only: [:test]},
       {:excoveralls, "~> 0.16", only: :test},
-      {:doctor, "~> 0.17.0"}
+      {:doctor, "~> 0.17.0"},
+      # needed for SSR
+      {:httpoison, "~> 2.0"}
     ]
   end
 


### PR DESCRIPTION
This adds support for server side rendering the head and body. It uses HTTPoison to fetch the data from the Inertia SSR server and only changes the body and head if that succeeds (with SSR enabled but an unavailable SSR server everything still works but warnings get logged) 